### PR TITLE
Handle unexpected errors gracefully

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -2,6 +2,11 @@ CHANGE_LOG
 
 For the Github commit log see here: github.com/jks-prv/kiwiclient/commits/master
 
+v1.7  July 12, 2025
+    Handle unexpected errors gracefully and reconnect automatically.
+    Connections now restart every 3 hours by default to prevent TCP latency.
+    Kiwi clients send the password proactively in the WebSocket URI.
+
 v1.6  July 11, 2025
     By request: The resampling option now works with netcat and camping modes.
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -2,7 +2,7 @@ CHANGE_LOG
 
 For the Github commit log see here: github.com/jks-prv/kiwiclient/commits/master
 
-v1.7  July 12, 2025
+v1.6.df0hq  July 12, 2025
     Handle unexpected errors gracefully and reconnect automatically.
     Connections now restart every 3 hours by default to prevent TCP latency.
     Kiwi clients send the password proactively in the WebSocket URI.

--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -167,12 +167,21 @@ class KiwiSDRStreamBase(object):
         prefix = getattr(self._options, 'http_prefix', '')
         if prefix:
             prefix = '/' + prefix.strip('/')
+        params = []
+        if self._camp_chan != -1:
+            params.append('camp')
+        if getattr(self._options, 'password', ''):
+            # proactive password login like the Kiwi web interface
+            p = urllib.quote_plus(self._options.password)
+            params.append('password=%s' % p)
+        query = ('?' + '&'.join(params)) if params else ''
+
         uri = '%s%s/%d/%s%s' % (
             prefix,
             '/wb' if self._options.wideband else '',
             self._options.ws_timestamp,
             which,
-            '?camp' if self._camp_chan != -1 else '')
+            query)
         if not uri.startswith('/'):
             uri = '/' + uri
         logging.debug('uri=<%s>' % uri)

--- a/kiwi/worker.py
+++ b/kiwi/worker.py
@@ -44,11 +44,17 @@ class KiwiWorker(threading.Thread):
 
             try:
                 self._recorder.open()
+                conn_start = time.time()
                 while self._do_run():
                     self._recorder.run()
                     # do things like freq changes while not receiving sound
                     if self._rigctld:
                         self._rigctld.run()
+                    if (self._options.restart_sec > 0 and
+                        time.time() - conn_start >= self._options.restart_sec):
+                        logging.info("restarting connection after %d seconds" %
+                                     self._options.restart_sec)
+                        raise KiwiServerTerminatedConnection('restart timer')
 
             except KiwiServerTerminatedConnection as e:
                 if self._options.no_api:

--- a/kiwi/worker.py
+++ b/kiwi/worker.py
@@ -97,7 +97,13 @@ class KiwiWorker(threading.Thread):
                 if self._options.is_kiwi_tdoa:
                     self._options.status = 1
                 print_exc()
-                break
+                logging.warn("Unexpected error. Reconnecting after 5 seconds: '%s'" % e)
+                self._recorder.close()
+                self.connect_count -= 1
+                if self._options.connect_retries > 0 and self.connect_count == 0:
+                    break
+                self._event.wait(timeout=5)
+                continue
 
         self._run_event.clear()   # tell all other threads to stop
         self._recorder.close()

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -416,6 +416,9 @@ def main():
     parser.add_option('-k', '--socket-timeout', '--socket_timeout',
                       dest='socket_timeout', type='int', default=10,
                       help='Socket timeout(sec) during data transfers')
+    parser.add_option('--restart-sec',
+                      dest='restart_sec', type='int', default=10800,
+                      help='Restart TCP connection after this many seconds (default 10800)')
     parser.add_option('--OV',
                       dest='ADC_OV',
                       default=False,

--- a/kiwiclientd_web.py
+++ b/kiwiclientd_web.py
@@ -557,6 +557,9 @@ def main():
     parser.add_option('-k', '--socket-timeout', '--socket_timeout',
                       dest='socket_timeout', type='int', default=10,
                       help='Socket timeout(sec) during data transfers')
+    parser.add_option('--restart-sec',
+                      dest='restart_sec', type='int', default=10800,
+                      help='Restart TCP connection after this many seconds (default 10800)')
     parser.add_option('--OV',
                       dest='ADC_OV',
                       default=False,


### PR DESCRIPTION
## Summary
- update KiwiWorker to retry on unknown exceptions
- proactively send password via query string when connecting

## Testing
- `pytest samplerate/tests/test_samplerate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872e633a45c832da7a9dfaafc1eb0af